### PR TITLE
added contig name to output of mash dist patlas proc

### DIFF
--- a/assemblerflow/generator/templates/mapping_patlas.nf
+++ b/assemblerflow/generator/templates/mapping_patlas.nf
@@ -6,6 +6,8 @@ process mappingBowtie_{{ pid }} {
 
     tag { "mapping sample: " + sample_id}
 
+    publishDir 'results/mapping_{{ pid }}/'
+
     input:
     set sample_id, file(reads) from {{ input_channel }}
     val bowtie2Index from IN_index_files
@@ -41,6 +43,8 @@ process samtoolsView_{{ pid }} {
 
     tag { "samtools commands: " +  sample_id }
 
+    publishDir 'results/mapping_{{ pid }}/'
+
     input:
     set sample_id, file(samtoolsFile) from bowtieResults
     val samtoolsIdx from IN_samtools_indexes
@@ -69,7 +73,7 @@ process jsonDumpingMapping_{{ pid }} {
 
     tag { "Dumping json: " +  sample_id }
 
-    publishDir 'results/mapping/'
+    publishDir 'results/mapping_{{ pid }}/'
 
     input:
     set sample_id, file(depthFile) from samtoolsResults

--- a/assemblerflow/generator/templates/mapping_patlas.nf
+++ b/assemblerflow/generator/templates/mapping_patlas.nf
@@ -6,7 +6,7 @@ process mappingBowtie_{{ pid }} {
 
     tag { "mapping sample: " + sample_id}
 
-    publishDir 'results/mapping_{{ pid }}/'
+    publishDir 'results/mapping/bowtie2_{{ pid }}/'
 
     input:
     set sample_id, file(reads) from {{ input_channel }}
@@ -43,7 +43,7 @@ process samtoolsView_{{ pid }} {
 
     tag { "samtools commands: " +  sample_id }
 
-    publishDir 'results/mapping_{{ pid }}/'
+    publishDir 'results/mapping/samtools_{{ pid }}/'
 
     input:
     set sample_id, file(samtoolsFile) from bowtieResults
@@ -73,7 +73,7 @@ process jsonDumpingMapping_{{ pid }} {
 
     tag { "Dumping json: " +  sample_id }
 
-    publishDir 'results/mapping_{{ pid }}/'
+    publishDir 'results/mapping/mapping_json_{{ pid }}/'
 
     input:
     set sample_id, file(depthFile) from samtoolsResults

--- a/assemblerflow/generator/templates/mash_dist.nf
+++ b/assemblerflow/generator/templates/mash_dist.nf
@@ -6,7 +6,7 @@ process runMashDist_{{ pid }} {
 
     tag { "running mash dist for fasta file: " + fasta }
 
-    publishDir 'results/mashdist_{{ pid }}/'
+    publishDir 'results/mashdist/mashdist_{{ pid }}/'
 
     input:
     set sample_id, file(fasta) from {{ input_channel }}
@@ -32,7 +32,7 @@ process mashDistOutputJson_{{ pid }} {
 
     tag { "dumping json file from: " + mashtxt }
 
-    publishDir 'results/mashdist_{{ pid }}/'
+    publishDir 'results/mashdist/mashdist_json_{{ pid }}/'
 
     input:
     set sample_id, fasta, file(mashtxt) from mashDistOutChannel_{{ pid }}

--- a/assemblerflow/generator/templates/mash_dist.nf
+++ b/assemblerflow/generator/templates/mash_dist.nf
@@ -32,7 +32,7 @@ process mashDistOutputJson_{{ pid }} {
 
     tag { "dumping json file from: " + mashtxt }
 
-    publishDir 'results/mashdist/'
+    publishDir 'results/mashdist_{{ pid }}/'
 
     input:
     set sample_id, fasta, file(mashtxt) from mashDistOutChannel_{{ pid }}

--- a/assemblerflow/generator/templates/mash_dist.nf
+++ b/assemblerflow/generator/templates/mash_dist.nf
@@ -6,6 +6,8 @@ process runMashDist_{{ pid }} {
 
     tag { "running mash dist for fasta file: " + fasta }
 
+    publishDir 'results/mashdist_{{ pid }}/'
+
     input:
     set sample_id, file(fasta) from {{ input_channel }}
     val refFile from IN_reference_file

--- a/assemblerflow/generator/templates/mash_screen.nf
+++ b/assemblerflow/generator/templates/mash_screen.nf
@@ -10,7 +10,7 @@ process mashScreen_{{ pid }} {
 
     tag { "running mash screen for sample: " + sample_id }
 
-    publishDir 'results/mashscreen_{{ pid }}/'
+    publishDir 'results/mashscreen/mashscreen_{{ pid }}/'
 
     input:
     set sample_id, file(reads) from {{ input_channel }}
@@ -36,7 +36,7 @@ process mashOutputJson_{{ pid }} {
 
     tag { "dumping json file from: " + mashtxt }
 
-    publishDir 'results/mashscreen/'
+    publishDir 'results/mashscreen/mashscreen_json_{{ pid }}'
 
     input:
     set sample_id, file(mashtxt) from mashScreenResults_{{ pid }}

--- a/assemblerflow/generator/templates/mash_screen.nf
+++ b/assemblerflow/generator/templates/mash_screen.nf
@@ -10,6 +10,8 @@ process mashScreen_{{ pid }} {
 
     tag { "running mash screen for sample: " + sample_id }
 
+    publishDir 'results/mashscreen_{{ pid }}/'
+
     input:
     set sample_id, file(reads) from {{ input_channel }}
     val refFile from IN_reference_file

--- a/assemblerflow/generator/templates/patlas_consensus.nf
+++ b/assemblerflow/generator/templates/patlas_consensus.nf
@@ -6,7 +6,7 @@ process fullConsensus {
 
     tag { "Creating consensus json file for: " + sample_id}
 
-    publishDir 'results/consensus/'
+    publishDir 'results/consensus_{{ pid }}/'
 
     input:
     set sample_id, file(infile_list) from {{ compile_channels }}

--- a/assemblerflow/templates/mashdist2json.py
+++ b/assemblerflow/templates/mashdist2json.py
@@ -23,8 +23,8 @@ Code documentation
 
 """
 
-__version__ = "1.1.1"
-__build__ = "03042018"
+__version__ = "1.2.0"
+__build__ = "17052018"
 __template__ = "mashsdist2json-nf"
 
 import os
@@ -121,7 +121,8 @@ def main(mash_output, hash_cutoff):
 
             # then if last_seq is equal to current_seq write to dict
             if last_seq == current_seq:
-                master_dict[ref_accession] = [1 - float(mash_dist), perc_hashes]
+                master_dict[ref_accession] = [1 - float(mash_dist), perc_hashes,
+                                              current_seq]
 
             last_seq = current_seq
 

--- a/assemblerflow/templates/mashdist2json.py
+++ b/assemblerflow/templates/mashdist2json.py
@@ -108,23 +108,8 @@ def main(mash_output, hash_cutoff):
         # reported to json file
         if perc_hashes > float(hash_cutoff):
 
-            #if last_seq != current_seq and counter > 0:
-                # create a new file only if master_dict is populated
-                #send_to_output(master_dict, mash_output)
-                #master_dict = {}
-                #counter = 0
-
-            # if counter = 0 last_seq should be updated before the next if statement
-            #if counter == 0:
-            #    counter += 1
-                #last_seq = current_seq
-
-            # then if last_seq is equal to current_seq write to dict
-            #if last_seq == current_seq:
             master_dict[ref_accession] = [1 - float(mash_dist), perc_hashes,
                                               current_seq]
-
-            #last_seq = current_seq
 
     # assures that file is closed in last iteration of the loop
     send_to_output(master_dict, mash_output)

--- a/assemblerflow/templates/mashdist2json.py
+++ b/assemblerflow/templates/mashdist2json.py
@@ -127,7 +127,7 @@ def main(mash_output, hash_cutoff):
             #last_seq = current_seq
 
     # assures that file is closed in last iteration of the loop
-    send_to_output(master_dict, last_seq, mash_output)
+    send_to_output(master_dict, mash_output)
 
 
 if __name__ == "__main__":

--- a/assemblerflow/templates/mashdist2json.py
+++ b/assemblerflow/templates/mashdist2json.py
@@ -108,23 +108,23 @@ def main(mash_output, hash_cutoff):
         # reported to json file
         if perc_hashes > float(hash_cutoff):
 
-            if last_seq != current_seq and counter > 0:
+            #if last_seq != current_seq and counter > 0:
                 # create a new file only if master_dict is populated
-                send_to_output(master_dict, last_seq, mash_output)
-                master_dict = {}
-                counter = 0
+                #send_to_output(master_dict, mash_output)
+                #master_dict = {}
+                #counter = 0
 
             # if counter = 0 last_seq should be updated before the next if statement
-            if counter == 0:
-                counter += 1
-                last_seq = current_seq
+            #if counter == 0:
+            #    counter += 1
+                #last_seq = current_seq
 
             # then if last_seq is equal to current_seq write to dict
-            if last_seq == current_seq:
-                master_dict[ref_accession] = [1 - float(mash_dist), perc_hashes,
+            #if last_seq == current_seq:
+            master_dict[ref_accession] = [1 - float(mash_dist), perc_hashes,
                                               current_seq]
 
-            last_seq = current_seq
+            #last_seq = current_seq
 
     # assures that file is closed in last iteration of the loop
     send_to_output(master_dict, last_seq, mash_output)

--- a/assemblerflow/templates/mashdist2json.py
+++ b/assemblerflow/templates/mashdist2json.py
@@ -43,7 +43,7 @@ if __file__.endswith(".command.sh"):
     logger.debug("HASH_CUTOFF: {}".format(HASH_CUTOFF))
 
 
-def send_to_output(master_dict, last_seq, mash_output):
+def send_to_output(master_dict, mash_output):
     """Send dictionary to output json file
     This function sends master_dict dictionary to a json file if master_dict is
     populated with entries, otherwise it won't create the file
@@ -67,8 +67,8 @@ def send_to_output(master_dict, last_seq, mash_output):
     """
     # create a new file only if master_dict is populated
     if master_dict:
-        out_file = open("{}_{}.json".format(
-            "".join(mash_output.split(".")[0]), last_seq), "w")
+        out_file = open("{}.json".format(
+            "".join(mash_output.split(".")[0])), "w")
         out_file.write(json.dumps(master_dict))
         out_file.close()
 


### PR DESCRIPTION
This PR adds contig name to patlas output json for mash dist process and changes mash dist to json output to a single file per sample rather than by contig.